### PR TITLE
Add possibilty to choose input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,61 @@
 
 One Time Password verification input component for Angular 7+.
 
-
 [Online demo](https://akhilmohanan.github.io/ng-otp/) is here.
-
 
 ## Installation and usage
 
 To install this component to an external project, follow the procedure:
 
- 1. **npm install ng-otp**
- 2. Add **NgOtpModule** import to your **@NgModule** like example below
-    ```javascript
-      import { BrowserModule } from '@angular/platform-browser';
-      import { NgModule } from '@angular/core';
-      import { AppComponent } from './app.component';
-      import { NgOtpModule } from 'ng-otp';
+1. **npm install ng-otp**
+2. Add **NgOtpModule** import to your **@NgModule** like example below
 
-      @NgModule({
-        declarations: [
-          AppComponent
-        ],
-        imports: [
-          BrowserModule,
-          NgOtpModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-      })
-      export class AppModule { }
+  ```javascript
+  import { BrowserModule } from '@angular/platform-browser';
+  import { NgModule } from '@angular/core';
+  import { AppComponent } from './app.component';
+  import { NgOtpModule } from 'ng-otp';
 
-    ```
-  3. Add **ng-otp** selector to template
-      ```html
-      <ng-otp [limit]="4" [acceptableCharacters]="characters" (otpOut)="setOtp($event)"></ng-otp>
-      ```
+  @NgModule({
+  declarations: [
+  AppComponent
+  ],
+  imports: [
+  BrowserModule,
+  NgOtpModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+  })
+  export class AppModule { }
+  ```
+
+  Add **ng-otp** selector to template
+
+```html
+<ng-otp [limit]="4" [allowedCharacters]="characters" (otpOut)="setOtp($event)"></ng-otp>
+```
 
 ## Attributes
-### options attribute
 
-Option | Default | Type | Description
------- | ------- | ---- | -----------
-limit | 4 | number | Enter the number of inputs in the OTP screen. By default limit is set to four.
-acceptableCharacters | '' | string | You can give a sting of characters you want, It's only allows these characters in input. By default it accpect all characters
+### Options attribute
+
+Option            | Default | Type                       | Description
+----------------- | ------- | -------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+limit             | 4       | number                     | Enter the number of inputs in the OTP screen. By default limit is set to four.
+allowedCharacters | /./     | string or RegExp           | You can give a string of characters you want. It's only allows these characters in input. It also accept a `Regex` to be able to test single character of input. By default it accpect all characters
+typeOfInput       | text    | `text` `password` `number` | Use native HTML input properties for selected type (like hided text in case of password and so on)
 
 ## Callbacks
+
 ### otpOut
-  * Called for every keyup,
-  * Output format is in string
+
+- Called every time the user fill the spaces (thought to send it to server)
+- Output format is in string
+
   ```javascript
   characters = 'abcdefghijklmnopqrstuvwxyz';
   setOtp(otp: string) {
-    console.log('the opt is ', otp);
+  console.log('the opt is ', otp);
   }
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-otp",
-  "version": "0.0.0",
+  "name": "ng-otp",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/ng-otp/package.json
+++ b/projects/ng-otp/package.json
@@ -1,8 +1,32 @@
 {
   "name": "ng-otp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"
-  }
+  },
+  "private": false,
+  "author": "Akhil M",
+  "description": "OTP verification implementation for faster integration",
+  "main": "public_api.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akhilmohanan/ng-otp.git"
+  },
+  "keywords": [
+    "otp",
+    "angular",
+    "otp-verification",
+    "angular otp",
+    "otp-input-box",
+    "otp-input"
+  ],
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/akhilmohanan/ng-otp/issues"
+  },
+  "homepage": "https://github.com/akhilmohanan/ng-otp#readme"
 }

--- a/projects/ng-otp/src/lib/ng-otp.component.html
+++ b/projects/ng-otp/src/lib/ng-otp.component.html
@@ -1,6 +1,18 @@
-<div [formGroup]="otpForm" class="otp-wrap">
-  <input type="tel" class="otp-input" maxlength="1" id="otp-{{i}}"
-          *ngFor="let control of limitArray; let i = index" placeholder="-"
-          (keyup)="changeFocus$.next(i)" (keydown)="onKeyDown($event)" (focusin)="onFocus(i)"
-          formControlName="otp-{{i}}">
+<div
+  [formGroup]="otpForm"
+  class="otp-wrap"
+>
+  <input
+    [type]="typeOfInput"
+    class="otp-input"
+    maxlength="1"
+    id="otp-{{i}}"
+    *ngFor="let control of limitArray; let i = index"
+    placeholder="-"
+    (keyup)="changeFocus$.next(i)"
+    (keydown)="onKeyDown($event)"
+    (focusin)="onFocus(i)"
+    formControlName="otp-{{i}}"
+    [attr.inputmode]="keyboardType"
+  >
 </div>

--- a/projects/ng-otp/src/lib/ng-otp.component.ts
+++ b/projects/ng-otp/src/lib/ng-otp.component.ts
@@ -72,6 +72,7 @@ export class NgOtpComponent implements OnInit, OnDestroy {
   }
 
   changeFocus(id: number) {
+    console.log(this.isKeyAcceptable);
     if (!this.isKeyAcceptable) {
       this.isKeyAcceptable = true;
       return;
@@ -110,7 +111,10 @@ export class NgOtpComponent implements OnInit, OnDestroy {
     if (event.key && (event.key !== 'Backspace' && event.key !== 'Delete')) {
       if (this._allowedCharacters) {
         if (this._allowedCharacters instanceof RegExp) {
-          this.isKeyAcceptable = this._allowedCharacters.test(event.key);
+          if (!this._allowedCharacters.test(event.key)) {
+            this.isKeyAcceptable = false;
+            event.preventDefault();
+          }
         } else {
           if (!this._allowedCharacters.includes(event.key)) {
             this.isKeyAcceptable = false;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,9 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<ng-otp [limit]="4" [acceptableCharacters]="characters" (otpOut)="setOtp($event)"></ng-otp>
+<ng-otp
+    [limit]="4"
+    [allowedCharacters]="characters"
+    (otpOut)="setOtp($event)"
+    typeOfInput="password"
+></ng-otp>
 
 <p> The opt is: <b>{{this.otp}}</b> </p>


### PR DESCRIPTION
Now it's possible to choose to set the **type** of `input` in with `password`, `text` and `number`.  
To be able to see the correct keyboard, even in mobile browser, the component, by the type passed, change the visualization of it.  
Furthermore it adds the possibilty to check the single character of each input not only with the string but also with a `Regular Expression`. 