### PR TITLE
Fix problem with LazyModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ Option            | Default | Type                       | Description
 ----------------- | ------- | -------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 limit             | 4       | number                     | Enter the number of inputs in the OTP screen. By default limit is set to four.
 allowedCharacters | /./     | string or RegExp           | You can give a string of characters you want. It's only allows these characters in input. It also accept a `Regex` to be able to test single character of input. By default it accpect all characters
-typeOfInput       | text    | `text` `password` `number` | Use native HTML input properties for selected type (like hided text in case of password and so on)
+typeOfInput       | `text`  | `text` `password` `number` | Use native HTML input properties for selected type (like hided text in case of password and so on)
+keyboardType      | `text`  | `text` `numeric`           | Use this attribute to change keyboard type even if `typeOfInput` is a different one
+
+`keyboardType` and `typeOfInput` **can be** a different type (e.g one password and one numeric)
 
 ## Callbacks
 

--- a/projects/ng-otp/src/lib/ng-otp.component.ts
+++ b/projects/ng-otp/src/lib/ng-otp.component.ts
@@ -4,6 +4,9 @@ import { NgOtpService } from './ng-otp.service';
 import { Subject, Subscription } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
 
+type InputType = 'text' | 'number' | 'password';
+type KeyboardType = 'numeric' | 'text';
+
 @Component({
   selector: 'ng-otp',
   templateUrl: './ng-otp.component.html',
@@ -12,9 +15,9 @@ import { throttleTime } from 'rxjs/operators';
 export class NgOtpComponent implements OnInit, OnDestroy {
 
   private _allowedCharacters: string | RegExp = /./;
-  private _typeOfInput: 'text' | 'number' | 'password' = 'text';
-  keyboardType: 'numeric' | 'text' = 'text';
+  private _typeOfInput: InputType = 'text';
 
+  @Input() keyboardType: KeyboardType = 'text';
   @Input() limit: number;
   @Input() set allowedCharacters(el: string | RegExp) {
     if (el) {
@@ -24,23 +27,22 @@ export class NgOtpComponent implements OnInit, OnDestroy {
     }
   }
 
-  @Input() set typeOfInput(type: 'text' | 'number' | 'password') {
+  @Input() set typeOfInput(type: InputType) {
     if (type) {
       this._typeOfInput = type;
-      this.keyboardType = type === 'number' ? 'numeric' : 'text';
     } else {
       this.throwErrorForUndefinedElement(type);
     }
   }
 
-  get typeOfInput(): 'text' | 'number' | 'password' {
+  get typeOfInput(): InputType {
     return this._typeOfInput;
   }
 
   @Output() otpOut = new EventEmitter();
 
   otpForm: FormGroup;
-  private limitArray = [];
+  limitArray = [];
   private isKeyAcceptable = true;
   changeFocus$ = new Subject();
   private subscription = new Subscription();

--- a/projects/ng-otp/src/lib/ng-otp.module.ts
+++ b/projects/ng-otp/src/lib/ng-otp.module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { NgOtpComponent } from './ng-otp.component';
 
-import {ReactiveFormsModule} from '@angular/forms';
-import { BrowserModule } from '@angular/platform-browser';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 @NgModule({
   declarations: [NgOtpComponent],
   imports: [
-    BrowserModule,
+    CommonModule,
     ReactiveFormsModule
   ],
   exports: [NgOtpComponent]


### PR DESCRIPTION
- Replace `BrowserModule` with `CommonModule` to be able to use the component even with `Lazy Modules`
- Add anoter `Input` to be able to have a more accurete control of type of input (e.g use a `type="password" but show keyboard as numeric`)